### PR TITLE
Fix log message punctuation

### DIFF
--- a/cmd/alertbridge/main.go
+++ b/cmd/alertbridge/main.go
@@ -72,7 +72,7 @@ func main() {
 		go func() {
 			<-shutdownCtx.Done()
 			if shutdownCtx.Err() == context.DeadlineExceeded {
-				log.Fatal("graceful shutdown timed out.. forcing exit.")
+				log.Fatal("graceful shutdown timed out... forcing exit.")
 			}
 		}()
 


### PR DESCRIPTION
## Summary
- adjust punctuation in `main.go`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684745c057148329bdfdc09d83e3fecc