### PR TITLE
Read request body once for HMAC verification

### DIFF
--- a/internal/auth/hmac.go
+++ b/internal/auth/hmac.go
@@ -4,7 +4,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"io"
 )
 
 type HMACVerifier struct {
@@ -21,15 +20,9 @@ func (v *HMACVerifier) IsEnabled() bool {
 	return v.secret != ""
 }
 
-func (v *HMACVerifier) Verify(body io.Reader, signature string) bool {
+func (v *HMACVerifier) Verify(bodyBytes []byte, signature string) bool {
 	if !v.IsEnabled() {
 		return true
-	}
-
-	// Read body
-	bodyBytes, err := io.ReadAll(body)
-	if err != nil {
-		return false
 	}
 
 	// Calculate HMAC

--- a/internal/handler/hook.go
+++ b/internal/handler/hook.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -55,7 +54,7 @@ func (h *HookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	// Verify HMAC if secret is set
 	if h.hmacVerifier.IsEnabled() {
 		signature := r.Header.Get("X-TV-Signature")
-		if !h.hmacVerifier.Verify(bytes.NewReader(bodyBytes), signature) {
+		if !h.hmacVerifier.Verify(bodyBytes, signature) {
 			h.logger.Error("invalid signature")
 			http.Error(w, "Invalid signature", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
## Summary
- verify HMAC using request bytes instead of re-reading the body
- simplify request handler to use the same byte slice for signature checking and JSON decoding

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68474e829ce0832983d59196b57bde80