### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	go build -o alertbridge ./cmd/alertbridge
 
 test:
-        go test -v ./...
+	go test -v ./...
 
 docker:
 	docker build -t alertbridge .


### PR DESCRIPTION
## Summary
- replace spaces with TAB for `test` target in Makefile

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68475fdf337483298a84454742e70994