### PR TITLE
Add Alpaca request logging

### DIFF
--- a/cmd/alertbridge/main.go
+++ b/cmd/alertbridge/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	// Initialize components
 	alpacaClient := adapter.NewAlpacaClient(alpacaKey, alpacaSecret, alpacaBase)
+	alpacaClient.SetLogger(logger)
 	hmacVerifier := auth.NewHMACVerifier(tvSecret)
 	riskGuard := risk.NewGuard(cooldownSec)
 


### PR DESCRIPTION
## Summary
- log Alpaca order requests and responses for debugging
- allow injecting logger into Alpaca client

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68484b5be96c832980024fd3d0a89b77