### PR TITLE
Add metrics endpoint and integration test

### DIFF
--- a/cmd/alertbridge/main.go
+++ b/cmd/alertbridge/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/njdaniel/alertbridge/internal/adapter"
 	"github.com/njdaniel/alertbridge/internal/handler"
 	"github.com/njdaniel/alertbridge/internal/risk"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
@@ -47,10 +48,15 @@ func main() {
 	// Initialize handler
 	hookHandler := handler.NewHookHandler(logger, alpacaClient, riskGuard)
 
+	// Create mux and register handlers
+	mux := http.NewServeMux()
+	mux.Handle("/hook", hookHandler)
+	mux.Handle("/metrics", promhttp.Handler())
+
 	// Create server
 	srv := &http.Server{
 		Addr:    ":" + port,
-		Handler: hookHandler,
+		Handler: mux,
 	}
 
 	// Start server in a goroutine

--- a/cmd/alertbridge/main_test.go
+++ b/cmd/alertbridge/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/njdaniel/alertbridge/internal/adapter"
+	"github.com/njdaniel/alertbridge/internal/handler"
+	"github.com/njdaniel/alertbridge/internal/risk"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func newTestAlpacaClient(t *testing.T) *adapter.AlpacaClient {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"1"}`))
+	}))
+	t.Cleanup(ts.Close)
+	return adapter.NewAlpacaClient("key", "secret", ts.URL)
+}
+
+func TestMetricsEndpoint(t *testing.T) {
+	t.Setenv("PROM_URL", "")
+	t.Setenv("PNL_MAX", "")
+	t.Setenv("PNL_MIN", "")
+
+	alpacaClient := newTestAlpacaClient(t)
+	g := risk.NewGuard("0")
+	h := handler.NewHookHandler(zap.NewNop(), alpacaClient, g)
+
+	mux := http.NewServeMux()
+	mux.Handle("/hook", h)
+	mux.Handle("/metrics", promhttp.Handler())
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed to get metrics: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add ServeMux and register metrics endpoint
- verify `/metrics` responds with HTTP 200

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848a9804fac8329b6f87abe614743aa