### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ docker run -p 3000:3000 \
   alertbridge
 ```
 
+## Docker Compose
+
+This repository includes a `docker-compose.yml` for running AlertBridge together
+with Prometheus, Grafana, and ngrok. Create a `.env` file based on
+`.env.example` with your Alpaca and ngrok credentials, then start the stack:
+
+```bash
+docker compose up
+```
+
+Services will be available on the following ports:
+
+- **AlertBridge:** <http://localhost:3000>
+- **Prometheus:** <http://localhost:9090>
+- **Grafana:** <http://localhost:3001> (admin/admin)
+- **ngrok UI:** <http://localhost:4040>
+
 ## Webhook Format
 
 Send POST requests to `/hook` with the following JSON body:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - prometheus
 
   ngrok:
-    image: wernight/ngrok:latest
+    image: wernight/ngrok:1.7.1
     command: ngrok http alertbridge:3000
     environment:
       - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - alertbridge
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:9.5.2
     ports:
       - "3001:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "3000:3000"
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.41.0
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  alertbridge:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - alertbridge
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+
+  ngrok:
+    image: wernight/ngrok:latest
+    command: ngrok http alertbridge:3000
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    ports:
+      - "4040:4040"
+    depends_on:
+      - alertbridge

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'alertbridge'
+    static_configs:
+      - targets: ['alertbridge:3000']


### PR DESCRIPTION
## Summary
- provide docker-compose.yml with AlertBridge, Prometheus, Grafana and ngrok
- add example Prometheus config
- document Docker Compose usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68504e70615c8329a52ea454e3bda57e