### PR TITLE
Add HMAC helper under handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Environment variables:
 - `PROM_URL`: Prometheus base URL for PnL checks (optional)
 - `PNL_MAX`: Maximum allowed PnL before blocking orders (optional)
 - `PNL_MIN`: Minimum allowed PnL before blocking orders (optional)
+- `TV_SECRET`: Shared secret for validating TradingView webhooks using the `X-TV-Signature` header (optional)
 
 ## Building
 
@@ -111,6 +112,7 @@ Important notes about the webhook format:
 - `side` must be either "buy" or "sell"
 - `qty` can be a number or "all"
 - `ts` is optional and should be Unix timestamp in milliseconds
+- When `TV_SECRET` is set, include an `X-TV-Signature` header with the HMAC SHA256 of the request body
 
 ## Metrics
 

--- a/cmd/alertbridge/main.go
+++ b/cmd/alertbridge/main.go
@@ -37,6 +37,7 @@ func main() {
 		port = "3000"
 	}
 	cooldownSec := os.Getenv("COOLDOWN_SEC")
+	tvSecret := os.Getenv("TV_SECRET")
 
 	// Initialize Alpaca client
 	alpacaClient := adapter.NewAlpacaClient(alpacaKey, alpacaSecret, alpacaBase)
@@ -46,7 +47,7 @@ func main() {
 	riskGuard := risk.NewGuard(cooldownSec)
 
 	// Initialize handler
-	hookHandler := handler.NewHookHandler(logger, alpacaClient, riskGuard)
+	hookHandler := handler.NewHookHandler(logger, alpacaClient, riskGuard, []byte(tvSecret))
 
 	// Create mux and register handlers
 	mux := http.NewServeMux()

--- a/cmd/alertbridge/main_test.go
+++ b/cmd/alertbridge/main_test.go
@@ -29,7 +29,7 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	alpacaClient := newTestAlpacaClient(t)
 	g := risk.NewGuard("0")
-	h := handler.NewHookHandler(zap.NewNop(), alpacaClient, g)
+	h := handler.NewHookHandler(zap.NewNop(), alpacaClient, g, nil)
 
 	mux := http.NewServeMux()
 	mux.Handle("/hook", h)

--- a/internal/auth/hmac.go
+++ b/internal/auth/hmac.go
@@ -1,4 +1,4 @@
-package handler
+package auth
 
 import (
 	"crypto/hmac"
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-// verifyHMAC checks the request body against the provided HMAC signature.
+// VerifyHMAC checks the request body against the provided HMAC signature.
 // When the secret is empty, the check is skipped.
-func verifyHMAC(secret []byte, body []byte, headerSig string) error {
+func VerifyHMAC(secret, body []byte, headerSig string) error {
 	if len(secret) == 0 {
 		return nil
 	}

--- a/internal/handler/hmac.go
+++ b/internal/handler/hmac.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// verifyHMAC checks the request body against the provided HMAC signature.
+// When the secret is empty, the check is skipped.
+func verifyHMAC(secret []byte, body []byte, headerSig string) error {
+	if len(secret) == 0 {
+		return nil
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(headerSig), []byte(expected)) {
+		return fmt.Errorf("invalid signature")
+	}
+	return nil
+}

--- a/internal/handler/hook.go
+++ b/internal/handler/hook.go
@@ -83,7 +83,7 @@ func (h *HookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 			h.logger.Error("invalid signature",
 				zap.Error(err),
 				zap.String("remote_addr", r.RemoteAddr),
-				zap.String("signature", sig))
+				zap.String("signature", sig[:8]+"..."))
 			http.Error(w, "Invalid signature", http.StatusUnauthorized)
 			return
 		}

--- a/internal/handler/hook.go
+++ b/internal/handler/hook.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/njdaniel/alertbridge/internal/adapter"
+	"github.com/njdaniel/alertbridge/internal/auth"
 	"github.com/njdaniel/alertbridge/internal/risk"
 	"github.com/njdaniel/alertbridge/pkg/metrics"
 )
@@ -78,7 +79,7 @@ func (h *HookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Missing signature", http.StatusUnauthorized)
 			return
 		}
-		if err := verifyHMAC(h.tvSecret, bodyBytes, sig); err != nil {
+		if err := auth.VerifyHMAC(h.tvSecret, bodyBytes, sig); err != nil {
 			h.logger.Error("invalid signature",
 				zap.Error(err),
 				zap.String("remote_addr", r.RemoteAddr),

--- a/internal/handler/hook_test.go
+++ b/internal/handler/hook_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/njdaniel/alertbridge/internal/adapter"
+	"github.com/njdaniel/alertbridge/internal/auth"
 	"github.com/njdaniel/alertbridge/internal/risk"
 )
 
@@ -71,7 +72,7 @@ func TestVerifyHMAC(t *testing.T) {
 	body := []byte("test")
 	secret := []byte("s")
 	sig := sign(string(secret), body)
-	if err := verifyHMAC(secret, body, sig); err != nil {
+	if err := auth.VerifyHMAC(secret, body, sig); err != nil {
 		t.Fatalf("expected valid signature, got %v", err)
 	}
 }
@@ -79,13 +80,13 @@ func TestVerifyHMAC(t *testing.T) {
 func TestVerifyHMACInvalid(t *testing.T) {
 	body := []byte("test")
 	secret := []byte("s")
-	if err := verifyHMAC(secret, body, "bad"); err == nil {
+	if err := auth.VerifyHMAC(secret, body, "bad"); err == nil {
 		t.Fatalf("expected error for invalid signature")
 	}
 }
 
 func TestVerifyHMACDisabled(t *testing.T) {
-	if err := verifyHMAC(nil, []byte("test"), "anything"); err != nil {
+	if err := auth.VerifyHMAC(nil, []byte("test"), "anything"); err != nil {
 		t.Fatalf("expected nil when secret empty, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- move verifyHMAC helper into `handler` package
- check webhook signatures in `HookHandler` using configured secret
- load `TV_SECRET` in main and pass it to the handler
- update unit tests
- document the optional `TV_SECRET` environment variable

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685080ca3e648329a4aeb652bcfc88dd