### PR TITLE
Add unit tests for adapter, main server, and risk PnL

### DIFF
--- a/cmd/alertbridge/server_test.go
+++ b/cmd/alertbridge/server_test.go
@@ -58,7 +58,7 @@ func TestServerStartupShutdown(t *testing.T) {
 	}
 
 	p, _ := os.FindProcess(os.Getpid())
-	p.Signal(syscall.SIGINT)
+	p.Signal(os.Interrupt)
 
 	select {
 	case <-done:

--- a/cmd/alertbridge/server_test.go
+++ b/cmd/alertbridge/server_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Test that the main server starts and shuts down when it receives an interrupt signal.
+func TestServerStartupShutdown(t *testing.T) {
+	alpacaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"1"}`))
+	}))
+	defer alpacaSrv.Close()
+
+	// find free port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	os.Setenv("ALP_KEY", "k")
+	os.Setenv("ALP_SECRET", "s")
+	os.Setenv("ALP_BASE", alpacaSrv.URL)
+	os.Setenv("PORT", fmt.Sprintf("%d", port))
+	os.Setenv("COOLDOWN_SEC", "0")
+	os.Setenv("PROM_URL", "")
+	os.Setenv("PNL_MAX", "")
+	os.Setenv("PNL_MIN", "")
+	os.Setenv("TV_SECRET", "")
+
+	done := make(chan struct{})
+	go func() {
+		main()
+		close(done)
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/metrics", port)
+	var resp *http.Response
+	for i := 0; i < 20; i++ {
+		resp, err = http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server not responding: %v", err)
+	}
+
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(syscall.SIGINT)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shutdown")
+	}
+}

--- a/internal/adapter/alpaca_test.go
+++ b/internal/adapter/alpaca_test.go
@@ -1,0 +1,91 @@
+package adapter
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestCreateOrderEquity(t *testing.T) {
+	var requestPath string
+	var requestBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		body, _ := ioutil.ReadAll(r.Body)
+		requestBody = body
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer ts.Close()
+
+	c := NewAlpacaClient("k", "s", ts.URL)
+	c.SetLogger(zap.NewNop())
+
+	order, err := c.CreateOrder("bot", "AAPL", "buy", "1")
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+	if order.ID != "abc" {
+		t.Fatalf("expected order id abc, got %s", order.ID)
+	}
+	if requestPath != "/v2/orders" {
+		t.Fatalf("expected path /v2/orders, got %s", requestPath)
+	}
+	var req map[string]interface{}
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if req["symbol"] != "AAPL" {
+		t.Fatalf("expected symbol AAPL, got %v", req["symbol"])
+	}
+	if req["time_in_force"] != "day" {
+		t.Fatalf("expected time_in_force day, got %v", req["time_in_force"])
+	}
+}
+
+func TestCreateOrderCrypto(t *testing.T) {
+	var requestBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		requestBody = body
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"xyz"}`))
+	}))
+	defer ts.Close()
+
+	c := NewAlpacaClient("k", "s", ts.URL)
+	c.SetLogger(zap.NewNop())
+
+	order, err := c.CreateOrder("bot", "ETHUSD", "sell", "0.5")
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+	if order.ID != "xyz" {
+		t.Fatalf("expected order id xyz, got %s", order.ID)
+	}
+	var req map[string]interface{}
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if req["time_in_force"] != "gtc" {
+		t.Fatalf("expected time_in_force gtc, got %v", req["time_in_force"])
+	}
+}
+
+func TestCreateOrderInvalidQty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	c := NewAlpacaClient("k", "s", ts.URL)
+	c.SetLogger(zap.NewNop())
+
+	if _, err := c.CreateOrder("bot", "AAPL", "buy", "bad"); err == nil {
+		t.Fatalf("expected error for invalid qty")
+	}
+}

--- a/internal/adapter/alpaca_test.go
+++ b/internal/adapter/alpaca_test.go
@@ -16,7 +16,10 @@ func TestCreateOrderEquity(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
-		body, _ := ioutil.ReadAll(r.Body)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
 		requestBody = body
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"id":"abc"}`))

--- a/internal/risk/guard_test.go
+++ b/internal/risk/guard_test.go
@@ -1,8 +1,10 @@
 package risk
 
 import (
-    "testing"
-    "time"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 )
 
 func TestGuardCooldown(t *testing.T) {
@@ -20,5 +22,59 @@ func TestGuardCooldown(t *testing.T) {
 	time.Sleep(1100 * time.Millisecond)
 	if err := g.Check("bot"); err != nil {
 		t.Fatalf("expected no error after cooldown: %v", err)
+	}
+}
+
+func TestGuardCheckPnLPass(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"result":[{"value":[0,"10"]}]}}`))
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	t.Setenv("PROM_URL", ts.URL)
+	t.Setenv("PNL_MAX", "15")
+	t.Setenv("PNL_MIN", "")
+
+	g := NewGuard("0")
+	if err := g.Check("bot"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestGuardCheckPnLMaxFail(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"result":[{"value":[0,"10"]}]}}`))
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	t.Setenv("PROM_URL", ts.URL)
+	t.Setenv("PNL_MAX", "5")
+	t.Setenv("PNL_MIN", "")
+
+	g := NewGuard("0")
+	if err := g.Check("bot"); err == nil {
+		t.Fatalf("expected pnl max error")
+	}
+}
+
+func TestGuardCheckPnLMinFail(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"result":[{"value":[0,"0"]}]}}`))
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	t.Setenv("PROM_URL", ts.URL)
+	t.Setenv("PNL_MAX", "")
+	t.Setenv("PNL_MIN", "1")
+
+	g := NewGuard("0")
+	if err := g.Check("bot"); err == nil {
+		t.Fatalf("expected pnl min error")
 	}
 }


### PR DESCRIPTION
## Summary
- test adapter/AlpacaClient.CreateOrder using httptest
- test server start and shutdown in cmd/main.go
- extend risk guard tests to cover PnL checks with mocked Prometheus

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850a07f0d008329947e29a85e86449a