### PR TITLE
Integrate SBOM and security artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.0
     - name: Install syft
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
     - name: go vet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
         go-version: 1.21
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.0
+    - name: Install syft
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
     - name: go vet
@@ -25,6 +28,18 @@ jobs:
     - name: go tool cover
       run: go tool cover -func=coverage.out
     - name: govulncheck
-      run: govulncheck ./...
+      run: govulncheck ./... > govulncheck.txt
+    - name: syft sbom
+      run: syft dir . -o spdx-json > sbom.spdx
     - name: staticcheck
       run: staticcheck ./...
+    - name: Upload govulncheck results
+      uses: actions/upload-artifact@v3
+      with:
+        name: govulncheck
+        path: govulncheck.txt
+    - name: Upload SBOM
+      uses: actions/upload-artifact@v3
+      with:
+        name: sbom
+        path: sbom.spdx

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ dist/
 
 # Test coverage
 coverage.txt
-coverage.html 
+coverage.html
+sbom.spdx


### PR DESCRIPTION
## Summary
- ignore generated `sbom.spdx`
- install syft in CI
- generate SPDX SBOM and upload to workflow artifacts
- upload `govulncheck` output as a workflow artifact

## Testing
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | head`
- `govulncheck ./... > govulncheck.txt` *(failed: runtime panic)*
- `syft scan dir:. -o spdx-json > sbom.spdx` *(warnings due to network restrictions)*
- `staticcheck ./...` *(failed: tool panic)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1e83d3c8329b9bddaef9daa1b2b