### PR TITLE
Add runbook documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Prometheus metrics are available at `/metrics`:
 
 - `order_total{bot,side}`: Counter of processed orders
 
+## Runbook
+See [docs/runbook.md](docs/runbook.md) for deployment, monitoring, and rollback steps.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,37 @@
+# Runbook
+
+This document explains how to deploy, monitor, and roll back AlertBridge in production environments.
+
+## Deployment
+
+1. **Build and test the binary**
+   ```bash
+   make build
+   make test
+   ```
+2. **Build the Docker image**
+   ```bash
+   docker build -t alertbridge:latest .
+   ```
+3. **Deploy** the container to your infrastructure or run the provided `docker-compose.yml` stack:
+   ```bash
+   docker compose up -d
+   ```
+
+## Monitoring
+
+- Prometheus metrics are exposed at `http://<host>:3000/metrics`. Use the provided `prometheus.yml` and Grafana dashboards to track request counts and errors.
+- Review container logs regularly for failed webhook deliveries or risk rule violations.
+
+## Rollback
+
+1. Identify the previous working Docker image tag or git commit.
+2. Redeploy using that tag:
+   ```bash
+   docker run -d --rm --name alertbridge_previous <image:tag>
+   ```
+3. If using Docker Compose, update the image tag in `docker-compose.yml` and run:
+   ```bash
+   docker compose up -d
+   ```
+


### PR DESCRIPTION
## Summary
- document deployment, monitoring and rollback steps in `docs/runbook.md`
- reference the runbook from the README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6850a4de099c83299292608b99521f1f