### PR TITLE
Add dockerignore and update README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Exclude version control
+.git
+
+# Test files
+/tests
+
+# SQLite and other database files
+*.db
+*.db-journal
+
+# Logs and coverage reports
+*.log
+coverage.*
+
+# Local environment and IDE files
+.env
+.env.*
+.idea/
+.vscode/
+
+# Build output
+alertbridge
+bin/
+dist/

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ export ALP_SECRET=your_secret
 
 ## Docker
 
+Use the provided Dockerfile together with the `.dockerignore` file to build the
+image:
+
 ```bash
-# Build and run with Docker
 docker build -t alertbridge .
 docker run -p 3000:3000 \
   -e ALP_KEY=your_key \


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep Docker build context small
- document how to build the Docker image using the Dockerfile and `.dockerignore`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6850aabc70448329b6b76c3e6ad1fe22