### PR TITLE
Update distroless base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o alertbridge ./cmd/alertbridge
 
 # Final stage
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:e6d589f36c6c7d9a14df69da026b446ac03c0d2027bfca82981b6a1256c2019c
 
 WORKDIR /app
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -35,3 +35,15 @@ This document explains how to deploy, monitor, and roll back AlertBridge in prod
    docker compose up -d
    ```
 
+## Base Image Digest Updates
+
+To pin the Docker base image to the latest Distroless digest:
+
+1. Fetch the current digest:
+   ```bash
+   curl -s https://gcr.io/v2/distroless/static-debian11/manifests/latest \
+     | grep -o 'sha256:[0-9a-f]\{64\}' | head -n 1
+   ```
+2. Update the `FROM` line in the `Dockerfile` with the retrieved digest.
+3. Rebuild and redeploy the image.
+


### PR DESCRIPTION
## Summary
- pin Dockerfile base image to a specific distroless digest
- add docs on how to update the digest in the runbook

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6850ab7a2a6883299de6f74c88003d3e