### PR TITLE
Update govulncheck/staticcheck versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       with:
         go-version: 1.21
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.0
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
     - name: Install syft
       run: |
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
     - name: go vet
       run: go vet ./...
     - name: go test
@@ -32,7 +32,12 @@ jobs:
     - name: syft sbom
       run: syft dir . -o spdx-json > sbom.spdx
     - name: staticcheck
-      run: staticcheck ./...
+      run: staticcheck ./... > staticcheck.txt
+    - name: Upload staticcheck results
+      uses: actions/upload-artifact@v3
+      with:
+        name: staticcheck
+        path: staticcheck.txt
     - name: Upload govulncheck results
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
## Summary
- bump govulncheck to v1.1.4
- bump staticcheck to v0.6.1
- save staticcheck output in CI artifacts

## Testing
- `go vet ./...` *(fails: undefined: testutil.NewRegistry)*
- `go test ./...` *(fails: undefined: testutil.NewRegistry)*
- `staticcheck ./... > /tmp/staticcheck.txt`
- `govulncheck ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d2d37c84832992012c31d078f37e