### PR TITLE
Add local env workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,19 @@
+# Copy this file to .env or .env.local and fill in your values
+
+# Alpaca API credentials
 ALP_KEY=
 ALP_SECRET=
+ALP_BASE=https://paper-api.alpaca.markets
+
+# Application settings
+PORT=3000
+COOLDOWN_SEC=0
+PROM_URL=
+PNL_MAX=
+PNL_MIN=
+TV_SECRET=
+
+# External services
 NGROK_AUTHTOKEN=
 GF_SECURITY_ADMIN_PASSWORD=
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment variables
 .env
+.env.local
 .env.*
 !.env.example
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ docker run -p 3000:3000 \
 ## Docker Compose
 
 This repository includes a `docker-compose.yml` for running AlertBridge together
-with Prometheus, Grafana, and ngrok. Create a `.env` file based on
-`.env.example` with your Alpaca, ngrok, and Grafana credentials, then start the stack:
+with Prometheus, Grafana, and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and Grafana credentials, then start the stack:
 
 ```bash
 docker compose up
@@ -93,6 +92,29 @@ Services will be available on the following ports:
 - **Prometheus:** <http://localhost:9090>
 - **Grafana:** <http://localhost:3001> (login with `GF_SECURITY_ADMIN_PASSWORD`)
 - **ngrok UI:** <http://localhost:4040>
+
+### Local vs Production
+
+1. Copy `.env.example` to `.env.local` and set your test credentials.
+2. Start the stack for local testing:
+
+```bash
+docker compose up
+```
+
+Expose the service with ngrok:
+
+```bash
+ngrok http 8080
+```
+
+For production, copy `.env.example` to `.env`, fill in real values, and run:
+
+```bash
+docker compose -f docker-compose.yml up -d
+```
+
+Use a reverse proxy like Caddy to serve HTTPS and forward traffic to AlertBridge.
 
 ## Webhook Format
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  alertbridge:
+    env_file:
+      - .env.local
+    ports:
+      - "8080:8080"
+  ngrok:
+    command: ngrok http alertbridge:8080
+


### PR DESCRIPTION
## Summary
- add `.env.example` template variables and dev `.env.local` ignore entry
- add `docker-compose.override.yml` for local development
- document switching between local and production modes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68558142ca5c8329aeba554fb53b2bbc