### PR TITLE
Add Caddy reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,6 @@ TV_SECRET=
 
 # External services
 NGROK_AUTHTOKEN=
-GF_SECURITY_ADMIN_PASSWORD=
+# Domain name used by Caddy for HTTPS
+DOMAIN=
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+{$DOMAIN} {
+    reverse_proxy alertbridge:3000
+}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Environment variables:
 - `PNL_MAX`: Maximum allowed PnL before blocking orders (optional)
 - `PNL_MIN`: Minimum allowed PnL before blocking orders (optional)
 - `TV_SECRET`: Shared secret for validating TradingView webhooks using the `X-TV-Signature` header (optional)
-- `GF_SECURITY_ADMIN_PASSWORD`: Grafana admin password when using Docker Compose
+- `DOMAIN`: Domain for Caddy HTTPS configuration
 
 ## Building
 
@@ -79,9 +79,7 @@ docker run -p 3000:3000 \
 
 ## Docker Compose
 
-This repository includes a `docker-compose.yml` for running AlertBridge together
-with Prometheus, Grafana, and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and Grafana credentials, then start the stack:
-
+This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and DOMAIN values, then start the stack:
 ```bash
 docker compose up
 ```
@@ -89,8 +87,7 @@ docker compose up
 Services will be available on the following ports:
 
 - **AlertBridge:** <http://localhost:3000>
-- **Prometheus:** <http://localhost:9090>
-- **Grafana:** <http://localhost:3001> (login with `GF_SECURITY_ADMIN_PASSWORD`)
+- **Caddy:** https://<your-domain> (ports 80 and 443)
 - **ngrok UI:** <http://localhost:4040>
 
 ### Local vs Production

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,23 @@ services:
       - .env.local
     ports:
       - "8080:8080"
+  caddy:
+    image: caddy:2
+    env_file:
+      - .env.local
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - alertbridge
   ngrok:
     command: ngrok http alertbridge:8080
+
+volumes:
+  caddy_data:
+  caddy_config:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,23 +7,19 @@ services:
     ports:
       - "3000:3000"
 
-  prometheus:
-    image: prom/prometheus:v2.41.0
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  caddy:
+    image: caddy:2
+    env_file:
+      - .env
     ports:
-      - "9090:9090"
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
     depends_on:
       - alertbridge
-
-  grafana:
-    image: grafana/grafana:9.5.2
-    ports:
-      - "3001:3000"
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
-    depends_on:
-      - prometheus
 
   ngrok:
     image: wernight/ngrok:1.7.1
@@ -34,3 +30,7 @@ services:
       - "4040:4040"
     depends_on:
       - alertbridge
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary
- replace Prometheus & Grafana with a Caddy reverse proxy
- update docker-compose.yml to use Caddy with persistent volumes
- document DOMAIN env var and remove Grafana variable
- add Caddyfile with reverse proxy configuration

## Testing
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68558a877b908329a36a8521fe896a31