### PR TITLE
Document environment setup and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,26 +92,34 @@ Services will be available on the following ports:
 
 ### Local vs Production
 
-1. Copy `.env.example` to `.env.local` and set your test credentials.
-2. Start the stack for local testing:
+Quick reference for running the stack in different environments. See
+[`docs/environments.md`](docs/environments.md) for full details.
 
-```bash
-docker compose up
-```
+**Local development**
 
-Expose the service with ngrok:
+1. Copy `.env.example` to `.env.local` and set test credentials.
+2. Start the stack:
 
-```bash
-ngrok http 8080
-```
+   ```bash
+   docker compose up
+   ```
 
-For production, copy `.env.example` to `.env`, fill in real values, and run:
+3. Expose the service externally with ngrok:
 
-```bash
-docker compose -f docker-compose.yml up -d
-```
+   ```bash
+   ngrok http 8080
+   ```
 
-Use a reverse proxy like Caddy to serve HTTPS and forward traffic to AlertBridge.
+**Production**
+
+1. Copy `.env.example` to `.env` and set real values (including `DOMAIN`).
+2. Start the stack in detached mode:
+
+   ```bash
+   docker compose -f docker-compose.yml up -d
+   ```
+
+   Caddy terminates HTTPS and forwards traffic to AlertBridge.
 
 ## Webhook Format
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,36 @@
+# Environment Setup
+
+This guide explains how to configure AlertBridge for local development and for production deployments. Use the provided example files to keep sensitive values out of version control.
+
+## .env.local vs .env
+
+1. Copy `.env.local.example` to `.env.local` for local development. Fill in your Alpaca credentials and any optional values like `NGROK_AUTHTOKEN`.
+2. Copy `.env.example` to `.env` for production deployments and set real API credentials. Include your production domain in the `DOMAIN` variable.
+3. Both `.env` and `.env.local` are ignored by Git (see `.gitignore`) so secrets won't be committed accidentally.
+
+Load either file when running Docker Compose with the `env_file` directive. `docker-compose.yml` uses `.env` by default while `docker-compose.override.yml` loads `.env.local` for development.
+
+## Local Testing with ngrok
+
+For quick testing against webhooks from external services, expose the local server using ngrok:
+
+```bash
+# Start the compose stack
+docker compose up
+
+# In another terminal, launch ngrok on port 8080
+ngrok http 8080
+```
+
+If you configured `NGROK_AUTHTOKEN` in `.env.local`, Docker Compose will start an ngrok container automatically.
+
+## Production with Caddy
+
+Production deployments typically run behind Caddy to provide HTTPS. Set the `DOMAIN` variable in `.env` and start the stack in detached mode:
+
+```bash
+docker compose -f docker-compose.yml up -d
+```
+
+Caddy reads `DOMAIN` from the environment and proxies HTTPS traffic to the AlertBridge container. See `Caddyfile` for the minimal reverse proxy configuration.
+


### PR DESCRIPTION
## Summary
- document safe usage of `.env.local` and `.env`
- add instructions for ngrok local testing
- describe production deployment with Caddy
- link to new doc from README with quick reference for local vs prod

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855959d89848329970ef8cbdaf51f74