### PR TITLE
Clarify env setup docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ## Docker Compose
 
-This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and DOMAIN values, then start the stack:
+This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (or `.env.production`) for production and place your Alpaca and DOMAIN values there. Use `.env.local` only if you need ngrok support by copying `.env.local.example` and setting `NGROK_AUTHTOKEN`, then start the stack:
 
 ```bash
 docker compose up
@@ -20,7 +20,7 @@ Quick reference for running the stack in different environments.
 
 #### Local development
 
-1. Copy `.env.local.example` to `.env.local` and set test credentials.
+1. Copy `.env.local.example` to `.env.local` only if you plan to use ngrok. The example file contains just `NGROK_AUTHTOKEN`.
 2. Start the stack:
 
    ```bash
@@ -35,7 +35,7 @@ Quick reference for running the stack in different environments.
 
 #### Production
 
-1. Copy `.env.example` to `.env` and set real values (including `DOMAIN`).
+1. Copy `.env.example` to `.env` (or `.env.production`) and set your Alpaca credentials and other real values such as `DOMAIN`.
 2. Start the stack in detached mode:
 
    ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ## Docker Compose
 
-This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (or `.env.production`) for production and place your Alpaca and DOMAIN values there. Use `.env.local` only if you need ngrok support by copying `.env.local.example` and setting `NGROK_AUTHTOKEN`, then start the stack:
+This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. For production, copy `.env.example` to `.env` (or `.env.production`) and place your Alpaca and DOMAIN values there. For local development with ngrok, copy `.env.local.example` to `.env.local`, set `NGROK_AUTHTOKEN`, and then start the stack:
 
 ```bash
 docker compose up

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -4,8 +4,8 @@ This guide explains how to configure AlertBridge for local development and for p
 
 ## .env.local vs .env
 
-1. Copy `.env.local.example` to `.env.local` for local development. Fill in your Alpaca credentials and any optional values like `NGROK_AUTHTOKEN`.
-2. Copy `.env.example` to `.env` for production deployments and set real API credentials. Include your production domain in the `DOMAIN` variable.
+1. Copy `.env.local.example` to `.env.local` if you want to run ngrok locally. The file now only provides `NGROK_AUTHTOKEN`.
+2. Copy `.env.example` to `.env` (or `.env.production`) for production deployments. Set your Alpaca credentials and include your production domain in the `DOMAIN` variable.
 3. Both `.env` and `.env.local` are ignored by Git (see `.gitignore`) so secrets won't be committed accidentally.
 
 Load either file when running Docker Compose with the `env_file` directive. `docker-compose.yml` uses `.env` by default while `docker-compose.override.yml` loads `.env.local` for development.


### PR DESCRIPTION
## Summary
- update environment documentation to explain `.env.local.example` now only includes ngrok token
- mention that Alpaca settings go in `.env` or `.env.production`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c3dfd5a708329ac224fe29e5f46c9