### PR TITLE
Replace fmt.Printf with logger warnings

### DIFF
--- a/cmd/alertbridge/main.go
+++ b/cmd/alertbridge/main.go
@@ -64,7 +64,7 @@ func main() {
 	alpacaClient.SetLogger(logger)
 
 	// Initialize risk guard
-	riskGuard := risk.NewGuard(cooldownSec)
+	riskGuard := risk.NewGuard(cooldownSec, logger)
 
 	// Initialize Slack notifier if configured
 	var notifier *notify.SlackNotifier

--- a/cmd/alertbridge/main_test.go
+++ b/cmd/alertbridge/main_test.go
@@ -28,7 +28,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	t.Setenv("PNL_MIN", "")
 
 	alpacaClient := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := handler.NewHookHandler(zap.NewNop(), alpacaClient, g, nil, nil, true, true)
 
 	mux := http.NewServeMux()
@@ -53,7 +53,7 @@ func TestHealthEndpoint(t *testing.T) {
 	t.Setenv("PNL_MIN", "")
 
 	alpacaClient := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := handler.NewHookHandler(zap.NewNop(), alpacaClient, g, nil, nil, true, true)
 
 	mux := http.NewServeMux()

--- a/internal/handler/hook_test.go
+++ b/internal/handler/hook_test.go
@@ -34,7 +34,7 @@ func newTestAlpacaClient(t *testing.T) *adapter.AlpacaClient {
 
 func TestHandleSuccess(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
@@ -49,7 +49,7 @@ func TestHandleSuccess(t *testing.T) {
 
 func TestHandleCooldown(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("1")
+	g := risk.NewGuard("1", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
@@ -93,7 +93,7 @@ func TestVerifyHMACDisabled(t *testing.T) {
 
 func TestHandleMissingSignature(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, []byte("s"), nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
@@ -108,7 +108,7 @@ func TestHandleMissingSignature(t *testing.T) {
 
 func TestHandleInvalidSignature(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, []byte("s"), nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
@@ -124,7 +124,7 @@ func TestHandleInvalidSignature(t *testing.T) {
 
 func TestHandleInvalidJSON(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader([]byte("{")))
@@ -138,7 +138,7 @@ func TestHandleInvalidJSON(t *testing.T) {
 
 func TestHandleMissingFields(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b"}`)
@@ -153,7 +153,7 @@ func TestHandleMissingFields(t *testing.T) {
 
 func TestHandleInvalidSide(t *testing.T) {
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"bad","qty":"1"}`)
@@ -179,7 +179,7 @@ func TestHandleRiskFail(t *testing.T) {
 	t.Setenv("PNL_MIN", "")
 
 	client := newTestAlpacaClient(t)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
@@ -199,7 +199,7 @@ func TestHandleOrderError(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	client := adapter.NewAlpacaClient("key", "secret", ts.URL)
-	g := risk.NewGuard("0")
+	g := risk.NewGuard("0", zap.NewNop())
 	h := NewHookHandler(zap.NewNop(), client, g, nil, nil, true, true)
 
 	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)

--- a/internal/risk/guard_test.go
+++ b/internal/risk/guard_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 func TestGuardCooldown(t *testing.T) {
@@ -12,7 +14,7 @@ func TestGuardCooldown(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("1")
+	g := NewGuard("1", zap.NewNop())
 	if err := g.Check("bot"); err != nil {
 		t.Fatalf("first check failed: %v", err)
 	}
@@ -37,7 +39,7 @@ func TestGuardCheckPnLPass(t *testing.T) {
 	t.Setenv("PNL_MAX", "15")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -55,7 +57,7 @@ func TestGuardCheckPnLMaxFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "5")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected pnl max error")
 	}
@@ -73,7 +75,7 @@ func TestGuardCheckPnLMinFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "1")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected pnl min error")
 	}
@@ -87,7 +89,7 @@ func TestGuardCheckPnLQueryError(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected query error")
 	}
@@ -103,7 +105,7 @@ func TestGuardCheckPnLStatusFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected status error")
 	}
@@ -120,7 +122,7 @@ func TestGuardCheckPnLDecodeFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected decode error")
 	}
@@ -137,7 +139,7 @@ func TestGuardCheckPnLValueTypeFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected value type error")
 	}
@@ -154,7 +156,7 @@ func TestGuardCheckPnLParseFail(t *testing.T) {
 	t.Setenv("PNL_MAX", "")
 	t.Setenv("PNL_MIN", "")
 
-	g := NewGuard("0")
+	g := NewGuard("0", zap.NewNop())
 	if err := g.Check("bot"); err == nil {
 		t.Fatalf("expected parse error")
 	}


### PR DESCRIPTION
## Summary
- warn via zap logger in risk guard
- pass logger to NewGuard so warnings use proper logger
- adjust main and tests for updated signature

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c3fc4def88329904a128d39bc342b