### PR TITLE
Align port with docker compose

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY alertbridge .
 
 # Expose port
-EXPOSE 3000
+EXPOSE 8080
 
 # Run the application
 CMD ["./alertbridge"] 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ AlertBridge is a headless gateway that receives TradingView (or any bot) webhook
    ```bash
    ./alertbridge
    ```
+4. By default the server listens on port `8080`. Override with the `PORT`
+   environment variable if needed.
 
 ## Configuration
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
-scrape_configs:
-  - job_name: 'alertbridge'
-    static_configs:
-      - targets: ['alertbridge:3000']
+  scrape_configs:
+    - job_name: 'alertbridge'
+      static_configs:
+        - targets: ['alertbridge:8080']


### PR DESCRIPTION
## Summary
- make `.docker/Dockerfile` expose 8080
- update `prometheus.yml` scrape port
- mention default port in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c3fc6d564832988e7f8c4f4fc4fdb