### PR TITLE
Handle Slack JSON marshalling errors

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+var jsonMarshal = json.Marshal
+
 var slackAPIURL = "https://slack.com/api/chat.postMessage"
 
 // SlackNotifier sends messages to Slack via webhook or OAuth token.
@@ -32,7 +34,7 @@ func NewSlackNotifier(webhookURL, token, channel string) *SlackNotifier {
 func (s *SlackNotifier) SendMessage(text string) error {
 	if s.webhookURL != "" {
 		payload := map[string]string{"text": text}
-		b, err := json.Marshal(payload)
+		b, err := jsonMarshal(payload)
 		if err != nil {
 			return err
 		}
@@ -49,7 +51,10 @@ func (s *SlackNotifier) SendMessage(text string) error {
 
 	if s.token != "" {
 		payload := map[string]string{"channel": s.channel, "text": text}
-		b, _ := json.Marshal(payload)
+		b, err := jsonMarshal(payload)
+		if err != nil {
+			return err
+		}
 		req, err := http.NewRequest("POST", slackAPIURL, bytes.NewReader(b))
 		if err != nil {
 			return err

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,5 +47,19 @@ func TestSendMessageToken(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("expected api to be called")
+	}
+}
+
+func TestSendMessageMarshalError(t *testing.T) {
+	n := NewSlackNotifier("http://example.com", "", "")
+	originalMarshal := jsonMarshal
+	jsonMarshal = func(v interface{}) ([]byte, error) {
+		type bad struct{ C chan int }
+		return json.Marshal(bad{})
+	}
+	defer func() { jsonMarshal = originalMarshal }()
+
+	if err := n.SendMessage("boom"); err == nil {
+		t.Fatalf("expected marshal error, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- return marshalling errors in Slack notifier
- test Slack SendMessage error handling by forcing json.Marshal failure

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c3fbff0188329a6fabfb1bee0ea83