### PR TITLE
Fix signature logging panic

### DIFF
--- a/internal/handler/hook.go
+++ b/internal/handler/hook.go
@@ -90,10 +90,14 @@ func (h *HookHandler) Handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := auth.VerifyHMAC(h.tvSecret, bodyBytes, sig); err != nil {
+			loggedSig := sig
+			if len(sig) >= 8 {
+				loggedSig = sig[:8] + "..."
+			}
 			h.logger.Error("invalid signature",
 				zap.Error(err),
 				zap.String("remote_addr", r.RemoteAddr),
-				zap.String("signature", sig[:8]+"..."))
+				zap.String("signature", loggedSig))
 			http.Error(w, "Invalid signature", http.StatusUnauthorized)
 			return
 		}

--- a/internal/handler/hook_test.go
+++ b/internal/handler/hook_test.go
@@ -122,6 +122,22 @@ func TestHandleInvalidSignature(t *testing.T) {
 	}
 }
 
+func TestHandleInvalidSignatureShort(t *testing.T) {
+	client := newTestAlpacaClient(t)
+	g := risk.NewGuard("0")
+	h := NewHookHandler(zap.NewNop(), client, g, []byte("s"), nil, true, true)
+
+	body := []byte(`{"bot":"b","symbol":"AAPL","side":"buy","qty":"1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(body))
+	req.Header.Set("X-TV-Signature", "bad")
+	rr := httptest.NewRecorder()
+
+	h.Handle(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
 func TestHandleInvalidJSON(t *testing.T) {
 	client := newTestAlpacaClient(t)
 	g := risk.NewGuard("0")


### PR DESCRIPTION
## Summary
- guard against short signatures in hook handler
- add test to confirm short signatures don't panic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c3fbad1648329aa982017d9787402