### PR TITLE
Fix registry URL in production env example

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,6 +1,6 @@
 # Copy this file to .env.production and fill in your values
 # Deployment settings
 IMAGE_TAG=latest
-REGISTRY=gchr.io/<your-github>
+REGISTRY=ghcr.io/<your-github>
 # Domain name used by Caddy for HTTPS
 DOMAIN=<your-domain>


### PR DESCRIPTION
## Summary
- correct the REGISTRY entry in `.env.production.example`
- ensure file ends with a newline

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c3ff3486083298093655b355f01a7