### PR TITLE
Fix Dockerfile newline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder /app/alertbridge .
 EXPOSE 8080
 
 # Run the application
-CMD ["./alertbridge"] 
+CMD ["./alertbridge"]


### PR DESCRIPTION
## Summary
- ensure the Dockerfile ends with a trailing newline to avoid prompt concatenation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c3ffb848083299a5b6fc6571fefea