### PR TITLE
Improve curl usage in scripts and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
     - name: Install syft
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
+        curl --fail --silent --show-error -L https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
     - name: go vet

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -73,7 +73,7 @@ To pin the Docker base image to the latest Distroless digest:
 
 1. Fetch the current digest:
    ```bash
-   curl -s https://gcr.io/v2/distroless/static-debian11/manifests/latest \
+   curl --fail --silent --show-error https://gcr.io/v2/distroless/static-debian11/manifests/latest \
      | grep -o 'sha256:[0-9a-f]\{64\}' | head -n 1
    ```
 2. Update the `FROM` line in the `Dockerfile` with the retrieved digest.
@@ -87,7 +87,7 @@ To regenerate the software bill of materials and vulnerability report:
 1. Install the tooling if not already available:
    ```bash
    go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-   curl -sSfL https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
+   curl --fail --silent --show-error -L https://raw.githubusercontent.com/anchore/syft/v0.84.0/install.sh | sh -s -- -b /usr/local/bin
    ```
 2. Run the scanners from the repository root:
    ```bash

--- a/scripts/curl_domain_webhook.sh
+++ b/scripts/curl_domain_webhook.sh
@@ -8,9 +8,12 @@ DOMAIN=${1:?Usage: $0 <domain>}
 send_webhook() {
     local url="https://$DOMAIN/hook"
     echo "Sending webhook to: $url"
-    curl -X POST "$url" \
+    if ! curl --fail --silent --show-error -X POST "$url" \
         -H "Content-Type: application/json" \
-        -d '{"bot":"test","symbol":"BTC/USD","side":"buy","qty":"0.0001"}'
+        -d '{"bot":"test","symbol":"BTC/USD","side":"buy","qty":"0.0001"}'; then
+        echo "Webhook request failed" >&2
+        return 1
+    fi
 }
 
 send_webhook

--- a/scripts/curl_ngrok_webhook.sh
+++ b/scripts/curl_ngrok_webhook.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Get the current ngrok public HTTPS URL
 ngrok_url() {
-    curl --silent http://127.0.0.1:4040/api/tunnels \
+    curl --fail --silent --show-error http://127.0.0.1:4040/api/tunnels \
         | jq -r '.tunnels[] | select(.proto=="https") | .public_url'
 }
 
@@ -16,9 +16,12 @@ send_webhook() {
         exit 1
     fi
     echo "Sending webhook to: $url"
-    curl -X POST "$url/hook" \
+    if ! curl --fail --silent --show-error -X POST "$url/hook" \
         -H "Content-Type: application/json" \
-        -d '{"bot":"test","symbol":"BTC/USD","side":"buy","qty":"0.0001"}'
+        -d '{"bot":"test","symbol":"BTC/USD","side":"buy","qty":"0.0001"}'; then
+        echo "Webhook request failed" >&2
+        return 1
+    fi
 }
 
 # Example usage


### PR DESCRIPTION
## Summary
- use `--fail --silent --show-error` for webhook curl scripts
- add error handling for failed curl requests
- update Alpaca test script with improved curl usage
- update docs and CI workflow to use explicit curl flags

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c400186308329aa3a42b67df5498b