### PR TITLE
docs: add running example

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,3 +43,18 @@ Quick reference for running the stack in different environments.
    ```
 
    Caddy terminates HTTPS and forwards traffic to AlertBridge.
+
+## Running from Source
+
+You can also run AlertBridge directly without Docker. Build the binary and execute it with your Alpaca credentials set as environment variables:
+
+```bash
+go build -o alertbridge ./cmd/alertbridge
+ALP_KEY=your_key ALP_SECRET=your_secret ./alertbridge
+```
+
+Alternatively run without building:
+
+```bash
+ALP_KEY=your_key ALP_SECRET=your_secret go run ./cmd/alertbridge
+```


### PR DESCRIPTION
## Summary
- add a section to the deployment docs showing how to run AlertBridge from source

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c4007eb3c8329915c2d7a9cc2b48b