### PR TITLE
Pin Dockerfile base images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.21-alpine AS builder
+FROM golang:1.21-alpine@sha256:8ee9b9e11ef79e314a7584040451a6df8e72a66712e741bf75951e05e587404e AS builder
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o alertbridge ./cmd/alertbridge
 
 # Final stage
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11@sha256:e6d589f36c6c7d9a14df69da026b446ac03c0d2027bfca82981b6a1256c2019c
 
 WORKDIR /app
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,15 @@
 
 ## Docker Compose
 
-This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and DOMAIN values, then start the stack:
+This repository includes a `docker-compose.yml` for running AlertBridge together with Caddy and ngrok. Copy `.env.example` to `.env` (production) or `.env.local` (development) and fill in your Alpaca, ngrok, and DOMAIN values, then start the stack. The `Dockerfile` pins its base images by digest to ensure reproducible builds and security:
+
+```Dockerfile
+FROM golang:1.21-alpine@sha256:8ee9b9e11ef79e314a7584040451a6df8e72a66712e741bf75951e05e587404e AS builder
+...
+FROM gcr.io/distroless/static-debian11@sha256:e6d589f36c6c7d9a14df69da026b446ac03c0d2027bfca82981b6a1256c2019c
+```
+
+Periodically update these digests using the steps in the [runbook](runbook.md).
 
 ```bash
 docker compose up

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -69,15 +69,20 @@ Grafana dashboards can visualize these metrics and alert statuses for quick tria
 
 ## Base Image Digest Updates
 
-To pin the Docker base image to the latest Distroless digest:
+Periodically refresh the pinned base images to include the latest security patches.
 
-1. Fetch the current digest:
+1. Fetch the current digest for the Go builder image:
+   ```bash
+   curl -s https://registry.hub.docker.com/v2/repositories/library/golang/tags/1.21-alpine \
+     | grep -o '"digest":"sha256:[0-9a-f]*"' | head -n 1
+   ```
+2. Fetch the current digest for Distroless:
    ```bash
    curl -s https://gcr.io/v2/distroless/static-debian11/manifests/latest \
      | grep -o 'sha256:[0-9a-f]\{64\}' | head -n 1
    ```
-2. Update the `FROM` line in the `Dockerfile` with the retrieved digest.
-3. Rebuild and redeploy the image.
+3. Update the `FROM` lines in the `Dockerfile` with the retrieved digests.
+4. Rebuild and redeploy the image.
 
 
 ## SBOM and Vulnerability Report Updates


### PR DESCRIPTION
## Summary
- pin `golang:1.21-alpine` and `gcr.io/distroless/static-debian11` to specific digests
- describe how to refresh digests in the runbook
- document the pinned digests in the deployment guide

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c403871148329a290cd4e73352602