### PR TITLE
Add jq dependency check to ngrok webhook script

### DIFF
--- a/scripts/curl_ngrok_webhook.sh
+++ b/scripts/curl_ngrok_webhook.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # Get the current ngrok public HTTPS URL
 ngrok_url() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Error: 'jq' is required but not installed. Please install jq to parse ngrok API responses." >&2
+        exit 1
+    fi
     curl --silent http://127.0.0.1:4040/api/tunnels \
         | jq -r '.tunnels[] | select(.proto=="https") | .public_url'
 }


### PR DESCRIPTION
## Summary
- check that `jq` exists in `curl_ngrok_webhook.sh` before parsing ngrok output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c40528c0c8329a0c09d594107e2d9