### PR TITLE
Add privacy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The `/healthz` endpoint returns `200 OK` and can be used for container liveness 
 ## Runbook
 See [docs/runbook.md](docs/runbook.md) for deployment, monitoring, and rollback steps.
 
+## Privacy
+
+See [docs/privacy.md](docs/privacy.md) for information on how webhook payloads are logged, how long logs are kept, and how to request deletion.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,15 @@
+# Privacy & Data Retention
+
+AlertBridge logs incoming webhook requests to aid debugging and auditing. Each log entry contains the remote IP address, user agent, and the full JSON payload that was sent to `/hook`.
+
+## Log Storage
+
+Logs are written to standard output. When running via Docker or another container runtime they are captured as container logs. The project itself does not store webhook payloads anywhere else.
+
+## Retention
+
+Container logs are rotated by the runtime. With Docker's default settings they are kept for about 30 days before being removed. If you ship the logs to an external system, retention will follow that system's policy.
+
+## Requesting Deletion
+
+To have a specific webhook payload removed from our logs before the retention period ends, open a GitHub issue with the timestamp and any relevant details. We will locate and delete the entry. If you operate your own instance, delete the corresponding logs from your logging system.


### PR DESCRIPTION
## Summary
- document log storage and retention
- add privacy policy reference in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c40d1849c83298e156fa39ecb1007