### PR TITLE
Update deployment docs for TLS Prometheus

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,3 +43,13 @@ Quick reference for running the stack in different environments.
    ```
 
    Caddy terminates HTTPS and forwards traffic to AlertBridge.
+
+### PROM_URL with HTTPS
+
+AlertBridge can query a Prometheus server for PnL metrics when the `PROM_URL` environment variable is set. For production deployments, configure this endpoint to use TLS and set the variable to the HTTPS URL:
+
+```env
+PROM_URL=https://prom.example.com
+```
+
+Ensure the Prometheus server presents a valid certificate so requests from AlertBridge succeed.


### PR DESCRIPTION
## Summary
- add guidance on configuring the `PROM_URL` environment variable
- show example with TLS enabled

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c40d3e9bc8329bce596142bcfbaad